### PR TITLE
able to delete user

### DIFF
--- a/components/UpdateUserAuth.jsx
+++ b/components/UpdateUserAuth.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
 import { FaGithub, FaFacebook, FaGoogle } from 'react-icons/fa';
 import Link from 'next/link';
+import deleteUser from '../supabase/deleteUser';
 
 export default function UpdateUserAuth() {
   const dispatch = useDispatch();
@@ -167,6 +168,8 @@ export default function UpdateUserAuth() {
           </button>
         </div>
       </form>
+      <hr/>
+      <button onClick={() => deleteUser(userInfo.id)}>Delete Your Account</button>
     </div>
   );
 }

--- a/components/UpdateUserAuth.jsx
+++ b/components/UpdateUserAuth.jsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
 import { FaGithub, FaFacebook, FaGoogle } from 'react-icons/fa';
 import Link from 'next/link';
-import deleteUser from '../supabase/deleteUser';
+import {deleteUser} from '../supabase/api/deleteUser';
 
 export default function UpdateUserAuth() {
   const dispatch = useDispatch();

--- a/components/UpdateUserAuth.jsx
+++ b/components/UpdateUserAuth.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import supabase from '../config/supabaseClient';
-import { checkSession } from '../store/reducers/userSlice';
+import { checkSession, logoutUser } from '../store/reducers/userSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
 import { FaGithub, FaFacebook, FaGoogle } from 'react-icons/fa';
 import Link from 'next/link';
 import {deleteUser} from '../supabase/api/deleteUser';
+import Router from 'next/router'
 
 export default function UpdateUserAuth() {
   const dispatch = useDispatch();
@@ -28,6 +29,12 @@ export default function UpdateUserAuth() {
       }
     }
   }, [userInfo]);
+
+  const handleDelete = () => {
+    deleteUser(userInfo.id);
+    dispatch(logoutUser(Router));
+  }
+
   const handleSubmitEmail = async (event) => {
     event.preventDefault();
     setSuccess({});
@@ -169,7 +176,7 @@ export default function UpdateUserAuth() {
         </div>
       </form>
       <hr/>
-      <button onClick={() => deleteUser(userInfo.id)}>Delete Your Account</button>
+      <button onClick={handleDelete}>Delete Your Account</button>
     </div>
   );
 }

--- a/components/UpdateUserAuth.jsx
+++ b/components/UpdateUserAuth.jsx
@@ -31,6 +31,7 @@ export default function UpdateUserAuth() {
   }, [userInfo]);
 
   const handleDelete = () => {
+    // deletes the user, their related information, and the immediately logs out
     deleteUser(userInfo.id);
     dispatch(logoutUser(Router));
   }

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -1,0 +1,9 @@
+import supabase from "../../config/supabaseClient";
+
+export const deleteUser = async (userId) => {
+    const { data, user, error } = await supabase.auth.api.deleteUser(userId);
+    if (error) {
+        return `some error occurred when trying to delete the user: ${error}`;
+    }
+    return data;
+}

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -1,9 +1,14 @@
 import supabase from "../../config/supabaseClient";
 
-export default deleteUser = async (userId) => {
+export const deleteUser = async (userId) => {
+    console.dir(userId);
+    // return true;
+    console.dir(supabase.auth.api.deleteUser);
     const { data, user, error } = await supabase.auth.api.deleteUser(userId);
     if (error) {
         return `some error occurred when trying to delete the user: ${error}`;
     }
+    console.dir(data);
+    console.dir(user);
     return data;
 }

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -4,7 +4,9 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_KEY;
+console.log(supabaseServiceKey)
 const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+console.dir(supabaseAdmin)
 
 export const deleteUser = async (userId) => {
     console.dir(userId);
@@ -14,7 +16,7 @@ export const deleteUser = async (userId) => {
     await supabaseAdmin.from('matches2').delete().eq('id', userId);
     await supabaseAdmin.from('messages').delete().or(`from.eq.${userId}, to.eq.${userId}`);
     // await supabaseAdmin.from('old_messages').delete().match({id:userId});
-    await supabaseAdmin.from('blacklist').delete().eq('id', userId);
+    await supabaseAdmin.from('blacklist').delete().or(`id.eq.${userId}, blacklised_id.eq.${userId}`);
     const filesToRemove = (await supabaseAdmin.storage.from('avatars').list()).data
         .reduce((prev, file) => {
             if (file.name.includes(userId)) {

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -1,6 +1,6 @@
 import supabase from "../../config/supabaseClient";
 
-export const deleteUser = async (userId) => {
+export default deleteUser = async (userId) => {
     const { data, user, error } = await supabase.auth.api.deleteUser(userId);
     if (error) {
         return `some error occurred when trying to delete the user: ${error}`;

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -7,9 +7,9 @@ const supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_KEY;
 // for some reason, the serviceKey does not properly create a client
 // with the role 'service_role'.
 // attempted to remove 'NEXT_PUBLIC' but createClient fails in such case
-console.log(supabaseServiceKey)
+
 const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
-console.dir(supabaseAdmin)
+
 // currently this data and the function below is NOT located on server side
 // this file is not protected and can be accessed from client-side 
 // further testing required

--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -1,14 +1,35 @@
-import supabase from "../../config/supabaseClient";
+import { createClient } from '@supabase/supabase-js';
+// creating a client just for admin access
+// NO OTHER PART OF THE APP SHOULD BE ACCESSING THIS CLIENT!!!
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_KEY;
+const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
 export const deleteUser = async (userId) => {
     console.dir(userId);
-    // return true;
-    console.dir(supabase.auth.api.deleteUser);
-    const { data, user, error } = await supabase.auth.api.deleteUser(userId);
+    await supabaseAdmin.from('profiles').delete().eq('id', userId);
+    await supabaseAdmin.from('profiles_secure').delete().eq('id', userId);
+    await supabaseAdmin.from('matches').delete().eq('id', userId);
+    await supabaseAdmin.from('matches2').delete().eq('id', userId);
+    await supabaseAdmin.from('messages').delete().or(`from.eq.${userId}, to.eq.${userId}`);
+    // await supabaseAdmin.from('old_messages').delete().match({id:userId});
+    await supabaseAdmin.from('blacklist').delete().eq('id', userId);
+    const filesToRemove = (await supabaseAdmin.storage.from('avatars').list()).data
+        .reduce((prev, file) => {
+            if (file.name.includes(userId)) {
+                prev.push(file.name);
+                return prev;
+            }
+            return prev;
+        }, []);
+    console.dir(filesToRemove);
+    const {data} = await supabaseAdmin.storage.from('avatars').remove(filesToRemove);
+    console.dir(data);
+    const { data: user, error } = await supabaseAdmin.auth.api.deleteUser(userId);
     if (error) {
         return `some error occurred when trying to delete the user: ${error}`;
     }
-    console.dir(data);
-    console.dir(user);
+    // console.dir(user);
     return data;
 }


### PR DESCRIPTION
success: user can delete their account and client immediately logs out/clears state

problems:
- service_role supabase client is NOT server side, and exposes the key to the public
- temporarily put auth.uid() and authorized role for all DELETE RLS because of the above issue
- ALL of a user's data is deleted: foreign key constraints do not allow us to delete a user without all of their related data
- deleting a user is not scalable: if we were to add more tables, would need to manually alter the deleteUser function
- --> this is because when we initially created all our tables, we did not allow for rows to cascade delete based on the uid