### PR TITLE
Update deleteUser.js

### DIFF
--- a/supabase/api/deleteUser.js
+++ b/supabase/api/deleteUser.js
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 // NO OTHER PART OF THE APP SHOULD BE ACCESSING THIS CLIENT!!!
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_KEY;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
 // for some reason, the serviceKey does not properly create a client
 // with the role 'service_role'.
 // attempted to remove 'NEXT_PUBLIC' but createClient fails in such case


### PR DESCRIPTION
testing for heroku without NEXT_PUBLIC
https://github.com/vercel/next.js/blob/canary/examples/environment-variables/.env.development
Secret keys need to be added to 
`.env.development.local`
on heroku - 
SUPABASE_SERVICE_KEY=****
this key addition and name change allowed build to succeed